### PR TITLE
remove false dependency on rdi during field subtraction

### DIFF
--- a/src/amd64/scalarmult_mulx_adx.inc
+++ b/src/amd64/scalarmult_mulx_adx.inc
@@ -226,9 +226,9 @@ mov    edi, 0
 mov    rcx, 38
 cmovae rcx, rdi
 sub    rax, rcx
-sbb    rbx, rdi
-sbb    rbp, rdi
-sbb    rsi, rdi
+sbb    rbx, 0
+sbb    rbp, 0
+sbb    rsi, 0
 cmovb  rdi, rcx
 sub    rax, rdi
 mov    qword ptr [rsp+32], rax
@@ -276,9 +276,9 @@ mov    edi, 0
 mov    rcx, 38
 cmovae rcx, rdi
 sub    rax, rcx
-sbb    rbx, rdi
-sbb    rbp, rdi
-sbb    rsi, rdi
+sbb    rbx, 0
+sbb    rbp, 0
+sbb    rsi, 0
 cmovb  rdi, rcx
 sub    rax, rdi
 mov    qword ptr [rsp+96], rax
@@ -679,9 +679,9 @@ mov    edi, 0
 mov    rcx, 38
 cmovae rcx, rdi
 sub    rax, rcx
-sbb    rbx, rdi
-sbb    rbp, rdi
-sbb    rsi, rdi
+sbb    rbx, 0
+sbb    rbp, 0
+sbb    rsi, 0
 cmovb  rdi, rcx
 sub    rax, rdi
 


### PR DESCRIPTION
IDK if this is worth it all for any reason besides readability since all 3 instructions have a dependency on the immediately preceding instruction through the carry flag (CF). 

If it's a good idea, there's a few other places where the changes can be applied. 