### PR TITLE
build: fix windows static lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ set_property(TARGET mx25519_static PROPERTY PUBLIC_HEADER include/mx25519.h)
 include_directories(mx25519_static
   include/)
 set_target_properties(mx25519_static PROPERTIES OUTPUT_NAME mx25519)
-target_compile_definitions(mx25519_static PRIVATE MX25519_STATIC)
+target_compile_definitions(mx25519_static PUBLIC MX25519_STATIC)
 
 add_executable(mx25519-tests
   tests/tests.c)


### PR DESCRIPTION
Correctly defines `MX25519_STATIC` for calling modules, so that mx25519's functions aren't marked `dllimport`. Also, remove unused `MX25519_PRIVATE`.

Should fix workflows like this?: https://github.com/monero-project/monero/actions/runs/25594653838/job/75138395042?pr=9559. Need someone to double check because I haven't used Windows in years. 