### PR TITLE
Unclamped API

### DIFF
--- a/include/mx25519.h
+++ b/include/mx25519.h
@@ -12,11 +12,14 @@
 
 /*
  * X25519 scalar (private key).
- * All private keys are implicitly multiples of 8 as the library only uses
- * bits 3-254. Bits 0-2 and 255 are internally set to 0.
- * Note that the key clamping procedure of this library differs from RFC 7748
- * by not setting the value of bit 254 to 1. This is done to support inverted
- * keys, which might have a zero bit in that position.
+ * Unless explicitly using an  "_unclamped" function, all private keys are
+ * "clamped": bits 0-2 and 255 are internally set to 0, and bit 254 is set to 1.
+ * This behavior matches RFC 7748. When using an "_unclamped" function, the key
+ * clamping is controlled by the value of passed `mx25519_unclamp_flags`.
+ * The unclamped behavior does *not* match RFC 7748, and is not compatible with
+ * programs which are RFC 7748 compliant. Unclamped operations are done to
+ * A) support inverted keys, which might have a zero bit in the 254th position,
+ * and B) support ECDH for existing legacy keys, which may not be clamped.
  */
 typedef struct mx25519_privkey {
     uint8_t data[32];
@@ -44,6 +47,21 @@ typedef enum mx25519_type {
     MX25519_TYPE_AMD64,     /* AMD64 assembly */
     MX25519_TYPE_AMD64X,    /* AMD64 assembly with MULX+ADX */
 } mx25519_type;
+
+/*
+ * Private key unclamp types.
+ *
+ * Please only use these flags if you know what you are doing. Using unclamped
+ * keys may produce incorrect results, or enable certain classes of
+ * cryptographic vulnerabilities. This library does not allow unclamping the
+ * 255th bit.
+ */
+typedef enum mx25519_unclamp_flags {
+    MX25519_UNCLAMP_NONE = 0, /* Fully clamped key, conforming to RFC 7748 */
+    MX25519_UNCLAMP_LSBS = 1, /* Unclamp the 3 LSBs, allowing 1s */
+    MX25519_UNCLAMP_254  = 2, /* Unclamp the 254th bit, allowing a 0 */
+    MX25519_UNCLAMP_ALL  = MX25519_UNCLAMP_LSBS | MX25519_UNCLAMP_254
+} mx25519_unclamp_flags;
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #define MX25519_WIN
@@ -103,6 +121,19 @@ MX25519_API void mx25519_scmul_base(const mx25519_impl* impl,
     mx25519_pubkey* result, const mx25519_privkey* key);
 
 /*
+ * Like `mx25519_scmul_base()`, but with RFC 7748 non-compliant clamping.
+ *
+ * @param impl is a pointer to an implementation. Must not be NULL.
+ * @param result is the pointer where the resulting public key will be stored.
+ *        Must not be NULL.
+ * @param key is a pointer to the private key. Must not be NULL.
+ * @param unclamp_flags is flags to describe the bits of the `key` to unclamp
+ */
+MX25519_API void mx25519_scmul_base_unclamped(const mx25519_impl* impl,
+    mx25519_pubkey* result, const mx25519_privkey* key,
+    mx25519_unclamp_flags unclamp_flags);
+
+/*
  * Calculates x(key*P), where P is a given public key.
  *
  * @param impl is a pointer to an implementation. Must not be NULL.
@@ -111,8 +142,23 @@ MX25519_API void mx25519_scmul_base(const mx25519_impl* impl,
  * @param key is a pointer to the private key. Must not be NULL.
  * @param p is a pointer to the base point P. Must not be NULL.
  */
-MX25519_API void mx25519_scmul_key(const mx25519_impl* impl, mx25519_pubkey* result,
-    const mx25519_privkey* key, const mx25519_pubkey* p);
+MX25519_API void mx25519_scmul_key(const mx25519_impl* impl,
+    mx25519_pubkey* result, const mx25519_privkey* key,
+    const mx25519_pubkey* p);
+
+/*
+ * Like `mx25519_scmul_key()`, but with RFC 7748 non-compliant clamping.
+ *
+ * @param impl is a pointer to an implementation. Must not be NULL.
+ * @param result is the pointer where the resulting public key will be stored.
+ *        Must not be NULL.
+ * @param key is a pointer to the private key. Must not be NULL.
+ * @param p is a pointer to the base point P. Must not be NULL.
+ * @param unclamp_flags is flags to describe the bits of the `key` to unclamp
+ */
+MX25519_API void mx25519_scmul_key_unclamped(const mx25519_impl* impl,
+    mx25519_pubkey* result, const mx25519_privkey* key,
+    const mx25519_pubkey* p, mx25519_unclamp_flags unclamp_flags);
 
 /*
  * Calculates invkey = 1/(key[0]*key[1]*...). This private key can be used

--- a/src/amd64/scalarmult.h
+++ b/src/amd64/scalarmult.h
@@ -11,10 +11,14 @@
 
 void mx25519_scalarmult_amd64(uint8_t* q,
     const uint8_t* n,
-    const uint8_t* p);
+    const uint8_t* p,
+    uint8_t clamp_lo,
+    uint8_t clamp_hi);
 
 void mx25519_scalarmult_amd64x(uint8_t* q,
     const uint8_t* n,
-    const uint8_t* p);
+    const uint8_t* p,
+    uint8_t clamp_lo,
+    uint8_t clamp_hi);
 
 #endif

--- a/src/amd64/scalarmult_compat.inc
+++ b/src/amd64/scalarmult_compat.inc
@@ -40,6 +40,8 @@
 ;#     rdi -> public key address (out)
 ;#     rsi -> private key address (in)
 ;#     rdx -> base point address (in)
+;#     rcx -> lo byte clamping mask
+;#     r8  -> hi byte clamping mask
 
 sub rsp, 392
 
@@ -70,21 +72,25 @@ mov    qword ptr [rsp+336], r14
 mov    qword ptr [rsp+344], r15
 
 ;# copy the private key and clamp it
+shl    r8, 56
+or     rcx, -8
+mov    r9, qword ptr [rsi+24]
+or     r9, r8
+mov    qword ptr [rsp+384], r9
 mov    r8, qword ptr [rsi]
-and    r8, -8
+and    r8, rcx
 mov    qword ptr [rsp+360], r8
 mov    r8, qword ptr [rsi+8]
 mov    qword ptr [rsp+368], r8
 mov    r8, qword ptr [rsi+16]
 mov    qword ptr [rsp+376], r8
-mov    r8, qword ptr [rsi+24]
-mov    qword ptr [rsp+384], r8
 
 ;# starting from bit 6 of the 31st byte
 mov    eax, 31
 mov    byte ptr [rsp+352], 6
 mov    byte ptr [rsp+353], 0
 mov    dword ptr [rsp+356], eax
+lea    rsi, [rsp+360]
 
 ;# load XP
 mov    r8, qword ptr [rdx]
@@ -1621,6 +1627,40 @@ mov    qword ptr [rsi+8], 0
 mov    qword ptr [rsi+16], 0
 mov    qword ptr [rsi+24], 0
 
+;# load select, AKA the LSB, then remove
+;# needed to support privkeys wth unclamped LSB
+mov bl, byte ptr [rsp+353]
+mov byte ptr [rsp+353], 0
+cmp bl, 1
+
+;# CSelect(X2,X3,select)
+mov    rsi, qword ptr [rsp+160]
+mov    rbp, qword ptr [rsp+168]
+mov    rcx, qword ptr [rsp+176]
+mov    rax, qword ptr [rsp+184]
+mov    r12, qword ptr [rsp+192]
+mov    r13, qword ptr [rsp+200]
+mov    r14, qword ptr [rsp+208]
+mov    r15, qword ptr [rsp+216]
+cmove  rsi, r12
+cmove  rbp, r13
+cmove  rcx, r14
+cmove  rax, r15
+
+;# CSelect(Z2,Z3,select)
+mov    r8, qword ptr [rsp+224]
+mov    r9, qword ptr [rsp+232]
+mov    r10, qword ptr [rsp+240]
+mov    r11, qword ptr [rsp+248]
+mov    r12, qword ptr [rsp+256]
+mov    r13, qword ptr [rsp+264]
+mov    r14, qword ptr [rsp+272]
+mov    r15, qword ptr [rsp+280]
+cmove  r8, r12
+cmove  r9, r13
+cmove  r10, r14
+cmove  r11, r15
+
 ;# result ← X2 · Z2^(-1)
 
 ;# result in: r8, r9, r10, r11
@@ -1632,21 +1672,11 @@ mov    qword ptr [rsi+24], 0
 ;# 128 T4
 ;# 352 invtable position (4 bytes)
 
-;# load result ← Z2
-mov    r8, qword ptr [rsp+224]
-mov    r9, qword ptr [rsp+232]
-mov    r10, qword ptr [rsp+240]
-mov    r11, qword ptr [rsp+248]
-
 ;# T0 ← X2
-mov    r12, qword ptr [rsp+160]
-mov    qword ptr [rsp+0], r12
-mov    r12, qword ptr [rsp+168]
-mov    qword ptr [rsp+8], r12
-mov    r12, qword ptr [rsp+176]
-mov    qword ptr [rsp+16], r12
-mov    r12, qword ptr [rsp+184]
-mov    qword ptr [rsp+24], r12
+mov    qword ptr [rsp+0], rsi
+mov    qword ptr [rsp+8], rbp
+mov    qword ptr [rsp+16], rcx
+mov    qword ptr [rsp+24], rax
 
 ;# T2 ← Z2
 mov    qword ptr [rsp+64], r8

--- a/src/amd64/scalarmult_gnu.S
+++ b/src/amd64/scalarmult_gnu.S
@@ -28,18 +28,20 @@
 ALIGN 32
 DECL(mx25519_scalarmult_amd64x):
 #ifdef WINABI
-  mov qword ptr [rsp+8], rdi
-  mov qword ptr [rsp+16], rsi
-  mov rdi, rcx
-  mov rsi, rdx
-  mov rdx, r8
+  mov   qword ptr [rsp+8], rdi
+  mov   qword ptr [rsp+16], rsi
+  mov   rdi, rcx
+  mov   rsi, rdx
+  mov   rdx, r8
+  mov   rcx, r9
+  movzx r8, byte ptr [rsp+40]
 #endif
 
 #include "scalarmult_mulx_adx.inc"
 
 #ifdef WINABI
-  mov rdi, qword ptr [rsp+8]
-  mov rsi, qword ptr [rsp+16]
+  mov   rdi, qword ptr [rsp+8]
+  mov   rsi, qword ptr [rsp+16]
 #endif
 
   ret
@@ -47,18 +49,20 @@ DECL(mx25519_scalarmult_amd64x):
 ALIGN 32
 DECL(mx25519_scalarmult_amd64):
 #ifdef WINABI
-  mov qword ptr [rsp+8], rdi
-  mov qword ptr [rsp+16], rsi
-  mov rdi, rcx
-  mov rsi, rdx
-  mov rdx, r8
+  mov   qword ptr [rsp+8], rdi
+  mov   qword ptr [rsp+16], rsi
+  mov   rdi, rcx
+  mov   rsi, rdx
+  mov   rdx, r8
+  mov   rcx, r9
+  movzx r8, byte ptr [rsp+40]
 #endif
 
 #include "scalarmult_compat.inc"
 
 #ifdef WINABI
-  mov rdi, qword ptr [rsp+8]
-  mov rsi, qword ptr [rsp+16]
+  mov   rdi, qword ptr [rsp+8]
+  mov   rsi, qword ptr [rsp+16]
 #endif
 
   ret

--- a/src/amd64/scalarmult_masm.asm
+++ b/src/amd64/scalarmult_masm.asm
@@ -15,30 +15,34 @@ PUBLIC mx25519_scalarmult_amd64
 include constants.inc
 
 mx25519_scalarmult_amd64x PROC
-  mov qword ptr [rsp+8], rdi
-  mov qword ptr [rsp+16], rsi
-  mov rdi, rcx
-  mov rsi, rdx
-  mov rdx, r8
+  mov   qword ptr [rsp+8], rdi
+  mov   qword ptr [rsp+16], rsi
+  mov   rdi, rcx
+  mov   rsi, rdx
+  mov   rdx, r8
+  mov   rcx, r9
+  movzx r8, byte ptr [rsp+40]
 
 include scalarmult_mulx_adx.inc
 
-  mov rdi, qword ptr [rsp+8]
-  mov rsi, qword ptr [rsp+16]
+  mov   rdi, qword ptr [rsp+8]
+  mov   rsi, qword ptr [rsp+16]
   ret
 mx25519_scalarmult_amd64x ENDP
 
 mx25519_scalarmult_amd64 PROC
-  mov qword ptr [rsp+8], rdi
-  mov qword ptr [rsp+16], rsi
-  mov rdi, rcx
-  mov rsi, rdx
-  mov rdx, r8
+  mov   qword ptr [rsp+8], rdi
+  mov   qword ptr [rsp+16], rsi
+  mov   rdi, rcx
+  mov   rsi, rdx
+  mov   rdx, r8
+  mov   rcx, r9
+  movzx r8, byte ptr [rsp+40]
 
 include scalarmult_compat.inc
 
-  mov rdi, qword ptr [rsp+8]
-  mov rsi, qword ptr [rsp+16]
+  mov   rdi, qword ptr [rsp+8]
+  mov   rsi, qword ptr [rsp+16]
   ret
 mx25519_scalarmult_amd64 ENDP
 

--- a/src/amd64/scalarmult_mulx_adx.inc
+++ b/src/amd64/scalarmult_mulx_adx.inc
@@ -40,6 +40,8 @@
 ;#     rdi -> public key address (out)
 ;#     rsi -> private key address (in)
 ;#     rdx -> base point address (in)
+;#     rcx -> lo byte clamping mask
+;#     r8  -> hi byte clamping mask
 
 sub rsp, 392
 
@@ -70,21 +72,25 @@ mov    qword ptr [rsp+336], r14
 mov    qword ptr [rsp+344], r15
 
 ;# copy the private key and clamp it
+shl    r8, 56
+or     rcx, -8
+mov    r9, qword ptr [rsi+24]
+or     r9, r8
+mov    qword ptr [rsp+384], r9
 mov    r8, qword ptr [rsi]
-and    r8, -8
+and    r8, rcx
 mov    qword ptr [rsp+360], r8
 mov    r8, qword ptr [rsi+8]
 mov    qword ptr [rsp+368], r8
 mov    r8, qword ptr [rsi+16]
 mov    qword ptr [rsp+376], r8
-mov    r8, qword ptr [rsi+24]
-mov    qword ptr [rsp+384], r8
 
 ;# starting from bit 6 of the 31st byte
 mov    eax, 31
 mov    byte ptr [rsp+352], 6
 mov    byte ptr [rsp+353], 0
 mov    dword ptr [rsp+356], eax
+lea    rsi, [rsp+360]
 
 ;# load XP
 mov    r8, qword ptr [rdx]
@@ -1169,6 +1175,40 @@ mov    qword ptr [rsi+8], 0
 mov    qword ptr [rsi+16], 0
 mov    qword ptr [rsi+24], 0
 
+;# load select, AKA the LSB, then remove
+;# needed to support privkeys wth unclamped LSB
+mov bl, byte ptr [rsp+353]
+mov byte ptr [rsp+353], 0
+cmp bl, 1
+
+;# CSelect(X2,X3,select)
+mov    rsi, qword ptr [rsp+160]
+mov    rbp, qword ptr [rsp+168]
+mov    rcx, qword ptr [rsp+176]
+mov    rax, qword ptr [rsp+184]
+mov    r12, qword ptr [rsp+192]
+mov    r13, qword ptr [rsp+200]
+mov    r14, qword ptr [rsp+208]
+mov    r15, qword ptr [rsp+216]
+cmove  rsi, r12
+cmove  rbp, r13
+cmove  rcx, r14
+cmove  rax, r15
+
+;# CSelect(Z2,Z3,select)
+mov    r8, qword ptr [rsp+224]
+mov    r9, qword ptr [rsp+232]
+mov    r10, qword ptr [rsp+240]
+mov    r11, qword ptr [rsp+248]
+mov    r12, qword ptr [rsp+256]
+mov    r13, qword ptr [rsp+264]
+mov    r14, qword ptr [rsp+272]
+mov    r15, qword ptr [rsp+280]
+cmove  r8, r12
+cmove  r9, r13
+cmove  r10, r14
+cmove  r11, r15
+
 ;# result ← X2 · Z2^(-1)
 
 ;# result in: r8, r9, r10, r11
@@ -1180,21 +1220,11 @@ mov    qword ptr [rsi+24], 0
 ;# 128 T4
 ;# 352 invtable position (4 bytes)
 
-;# load result ← Z2
-mov    r8, qword ptr [rsp+224]
-mov    r9, qword ptr [rsp+232]
-mov    r10, qword ptr [rsp+240]
-mov    r11, qword ptr [rsp+248]
-
 ;# T0 ← X2
-mov    r12, qword ptr [rsp+160]
-mov    qword ptr [rsp+0], r12
-mov    r12, qword ptr [rsp+168]
-mov    qword ptr [rsp+8], r12
-mov    r12, qword ptr [rsp+176]
-mov    qword ptr [rsp+16], r12
-mov    r12, qword ptr [rsp+184]
-mov    qword ptr [rsp+24], r12
+mov    qword ptr [rsp+0], rsi
+mov    qword ptr [rsp+8], rbp
+mov    qword ptr [rsp+16], rcx
+mov    qword ptr [rsp+24], rax
 
 ;# T2 ← Z2
 mov    qword ptr [rsp+64], r8

--- a/src/arm64/scalarmult.S
+++ b/src/arm64/scalarmult.S
@@ -113,16 +113,19 @@ DECL(mx25519_scalarmult_arm64):
 
 	// 0: mask1, 8: mask2, 16: AA, 56: B/BB, 96: counter, 100: lastbit, 104: scalar, 136: X1, 176: outptr, 184: padding, 192: fp, 200: lr
 
+	orr	x9, x3, #0xfffffffffffffff8 // clamp_lo -> u64
+	lsl	x10, x4, #56                // clamp_hi -> u64
+
 	str	x0, [sp, #176] // outptr
 	mov	x19, x2 // point
 
 	mov	x0, x1 // scalar
 	bl	load256unaligned
 
-	and	x3, x3, #0x7fffffffffffffff
-	and	x0, x0, #0xfffffffffffffff8
-	//orr	x3, x3, #0x4000000000000000 //do not set bit 254
+	and	x0, x0, x9  // clamp lo byte
+	orr	x3, x3, x10 // clamp hi byte
 
+	// store clamped key
 	stp	x0, x1, [sp, #104]
 	stp	x2, x3, [sp, #104+16]
 
@@ -1199,6 +1202,20 @@ mov	v10.d[0], v0.d[1]
 	// Z5 -> Z3 in v11, v13, ..., v19
 
 	bpl	.Lmainloop
+
+	tst	w3, #1
+
+	fcsel	d1, d1, d11, eq
+	fcsel	d3, d3, d13, eq
+	fcsel	d5, d5, d15, eq
+	fcsel	d7, d7, d17, eq
+	fcsel	d9, d9, d19, eq
+
+	fcsel	d0, d0, d10, eq
+	fcsel	d2, d2, d12, eq
+	fcsel	d4, d4, d14, eq
+	fcsel	d6, d6, d16, eq
+	fcsel	d8, d8, d18, eq
 
 	mov	w0, v1.s[0]
 	mov	w1, v1.s[1]

--- a/src/arm64/scalarmult.h
+++ b/src/arm64/scalarmult.h
@@ -11,6 +11,8 @@
 
 void mx25519_scalarmult_arm64(uint8_t* q,
     const uint8_t* n,
-    const uint8_t* p);
+    const uint8_t* p,
+    const uint8_t clamp_lo,
+    const uint8_t clamp_hi);
 
 #endif

--- a/src/impl.h
+++ b/src/impl.h
@@ -11,7 +11,11 @@
 
 #include <stdint.h>
 
-typedef void scmul_func(uint8_t result[32], const uint8_t key[32], const uint8_t base[32]);
+typedef void scmul_func(uint8_t result[32],
+    const uint8_t key[32],
+    const uint8_t base[32],
+    uint8_t clamp_lo,
+    uint8_t clamp_hi);
 
 typedef struct mx25519_impl {
     scmul_func* scmul;

--- a/src/mx25519.c
+++ b/src/mx25519.c
@@ -62,6 +62,24 @@ static mx25519_type select_best_impl(void) {
 #endif
 }
 
+static void clamp_and_dispatch(const mx25519_impl* impl,
+    mx25519_pubkey* result, const mx25519_privkey* key,
+    const mx25519_pubkey* pt, mx25519_unclamp_flags unclamp_flags)
+{
+    const uint8_t lsb_mask = 248 | ((unclamp_flags & MX25519_UNCLAMP_LSBS) * 7);
+    const uint8_t msb_mask = (~unclamp_flags & MX25519_UNCLAMP_254) << 5;
+
+    assert(impl != NULL);
+    assert(pt != NULL);
+    assert(key != NULL);
+    assert(result != NULL);
+    assert(impl->scmul != NULL);
+    assert(impl->type <= MX25519_TYPE_AMD64X);
+
+    /* dispatch */
+    impl->scmul(result->data, key->data, pt->data, lsb_mask, msb_mask);
+}
+
 const mx25519_impl* mx25519_select_impl(mx25519_type type)
 {
     if (type == MX25519_TYPE_AUTO) {
@@ -83,20 +101,27 @@ mx25519_type mx25519_impl_type(const mx25519_impl* impl)
 void mx25519_scmul_base(const mx25519_impl* impl, mx25519_pubkey* result,
     const mx25519_privkey* key)
 {
-    assert(impl != NULL);
-    assert(key != NULL);
-    assert(result != NULL);
-    impl->scmul(result->data, key->data, x25519_base.data);
+    clamp_and_dispatch(impl, result, key, &x25519_base, MX25519_UNCLAMP_NONE);
+}
+
+void mx25519_scmul_base_unclamped(const mx25519_impl* impl,
+    mx25519_pubkey* result, const mx25519_privkey* key,
+    mx25519_unclamp_flags unclamp_flags)
+{
+    clamp_and_dispatch(impl, result, key, &x25519_base, unclamp_flags);
 }
 
 void mx25519_scmul_key(const mx25519_impl* impl, mx25519_pubkey* result,
     const mx25519_privkey* key, const mx25519_pubkey* pt)
 {
-    assert(impl != NULL);
-    assert(pt != NULL);
-    assert(key != NULL);
-    assert(result != NULL);
-    impl->scmul(result->data, key->data, pt->data);
+    clamp_and_dispatch(impl, result, key, pt, MX25519_UNCLAMP_NONE);
+}
+
+void mx25519_scmul_key_unclamped(const mx25519_impl* impl,
+    mx25519_pubkey* result, const mx25519_privkey* key,
+    const mx25519_pubkey* pt, mx25519_unclamp_flags unclamp_flags)
+{
+    clamp_and_dispatch(impl, result, key, pt, unclamp_flags);
 }
 
 int mx25519_invkey(mx25519_privkey* invkey, const mx25519_privkey keys[],

--- a/src/portable/scalarmult.c
+++ b/src/portable/scalarmult.c
@@ -9,7 +9,9 @@
 
 void mx25519_scalarmult_portable(uint8_t* q,
     const uint8_t* n,
-    const uint8_t* p)
+    const uint8_t* p,
+    const uint8_t clamp_lo,
+    const uint8_t clamp_hi)
 {
     uint8_t e[32];
     unsigned int i;
@@ -25,9 +27,9 @@ void mx25519_scalarmult_portable(uint8_t* q,
     unsigned int b;
 
     for (i = 0; i < 32; ++i) e[i] = n[i];
-    e[0] &= 248;
-    e[31] &= 127;
-    //e[31] |= 64; do not set bit 254
+    e[0] &= clamp_lo;
+    e[31] |= clamp_hi;
+    // bit 255 is cleared implicitly by virtue of ignoring it
     fe_frombytes(x1, p);
     fe_1(x2);
     fe_0(z2);

--- a/src/portable/scalarmult.h
+++ b/src/portable/scalarmult.h
@@ -11,6 +11,8 @@
 
 void mx25519_scalarmult_portable(uint8_t* q,
     const uint8_t* n,
-    const uint8_t* p);
+    const uint8_t* p,
+    uint8_t clamp_lo,
+    uint8_t clamp_hi);
 
 #endif

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -26,12 +26,11 @@ static void run_test(const char* name, test_func* func) {
 }
 
 /* RFC 7748 test vectors */
-/* the second most significant bit of each private key was set to 1 to match the RFC results */
 static const char rfc7748_sc1[] = "a546e36bf0527c9d3b16154b82465edd62144c0ac1fc5a18506a2244ba449ac4";
 static const char rfc7748_pt1[] = "e6db6867583030db3594c1a424b15f7c726624ec26b3353b10a903a6d0ab1c4c";
 static const char rfc7748_re1[] = "c3da55379de9c6908e94ea4df28d084f32eccf03491c71f754b4075577a28552";
 
-static const char rfc7748_sc2[] = "4b66e9d4d1b4673c5ad22691957d6af5c11b6421e0ea01d42ca4169e7918ba4d";
+static const char rfc7748_sc2[] = "4b66e9d4d1b4673c5ad22691957d6af5c11b6421e0ea01d42ca4169e7918ba0d";
 static const char rfc7748_pt2[] = "e5210f12786811d3f4b7959d0538ae2c31dbe7106fc03c3efc4cd549c715a493";
 static const char rfc7748_re2[] = "95cbde9476e8907d7aade45cb4b873f88b595a68799fa152e6f8f7647aac7957";
 
@@ -46,7 +45,7 @@ const char test_pt4[] = "08558f428dff0dc8ee4bebf2408982cf65538a3ae57dffe4f49f43f
 const char test_re4[] = "cd178e864e4f3dd3f5e945c04b87825b84d8a224b6c240784515c5f87af27647";
 
 /* DH key exchange tests */
-static const char rfc7748_alice_priv[] = "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c6a";
+static const char rfc7748_alice_priv[] = "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a";
 static const char rfc7748_alice_pub[] = "8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a";
 static const char rfc7748_bob_priv[] = "5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb";
 static const char rfc7748_bob_pub[] = "de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f";
@@ -88,15 +87,21 @@ static inline bool equals_hex(const void* val, const char* hex) {
     return memcmp(val, reference, sizeof(reference)) == 0;
 }
 
-static bool check_scmul(const char* key_hex, const char* pt_hex, const char* res_hex) {
+static bool check_scmul_unclamped(const char* key_hex, const char* pt_hex,
+    const char* res_hex, mx25519_unclamp_flags unclamp_flags)
+{
     assert(impl != NULL);
     mx25519_privkey key;
     load_key(key, key_hex);
     mx25519_pubkey pt;
     load_key(pt, pt_hex);
     mx25519_pubkey res;
-    mx25519_scmul_key(impl , &res, &key, &pt);
+    mx25519_scmul_key_unclamped(impl , &res, &key, &pt, unclamp_flags);
     return equals_hex(res.data, res_hex);
+}
+
+static bool check_scmul(const char* key_hex, const char* pt_hex, const char* res_hex) {
+    return check_scmul_unclamped(key_hex, pt_hex, res_hex, MX25519_UNCLAMP_NONE);
 }
 
 static void check_dh() {
@@ -151,12 +156,27 @@ static bool test_scmul3_portable() {
 }
 
 static bool test_scmul4_portable() {
-    assert(check_scmul(test_sc4, test_pt4, test_re4));
+    assert(check_scmul_unclamped(test_sc4, test_pt4, test_re4, MX25519_UNCLAMP_254));
     return true;
 }
 
 static bool test_dh_portable() {
     check_dh();
+    return true;
+}
+
+static bool test_mul_base_times1_portable() {
+    if (impl == NULL) {
+        return false;
+    }
+
+    // check that mx25519_scmul_base(1) == B
+    const mx25519_privkey one = {.data = {1}};
+    const mx25519_pubkey B = {.data = {9}};
+    mx25519_pubkey B1;
+    mx25519_scmul_base_unclamped(impl, &B1, &one, MX25519_UNCLAMP_ALL);
+
+    assert(memcmp(&B1, &B, sizeof(B)) == 0);
     return true;
 }
 
@@ -166,7 +186,7 @@ static bool test_invert1() {
     assert(equals_hex(&invkey, inv_1));
     mx25519_pubkey res;
     load_key(res, inv_pubkey);
-    mx25519_scmul_key(impl, &res, &invkey, &res);
+    mx25519_scmul_key_unclamped(impl, &res, &invkey, &res, MX25519_UNCLAMP_254);
     assert(equals_hex(&res, inv_pubkey));
     return true;
 }
@@ -179,13 +199,13 @@ static bool test_invert2() {
     load_key(keys[2], inv_priv3);
     mx25519_pubkey res;
     load_key(res, inv_pubkey);
-    mx25519_scmul_key(impl, &res, &keys[0], &res);
-    mx25519_scmul_key(impl, &res, &keys[1], &res);
-    mx25519_scmul_key(impl, &res, &keys[2], &res);
+    mx25519_scmul_key_unclamped(impl, &res, &keys[0], &res, MX25519_UNCLAMP_254);
+    mx25519_scmul_key_unclamped(impl, &res, &keys[1], &res, MX25519_UNCLAMP_254);
+    mx25519_scmul_key_unclamped(impl, &res, &keys[2], &res, MX25519_UNCLAMP_254);
     mx25519_privkey invkey;
     int fail = mx25519_invkey(&invkey, keys, NUM_KEYS);
     assert(!fail);
-    mx25519_scmul_key(impl, &res, &invkey, &res);
+    mx25519_scmul_key_unclamped(impl, &res, &invkey, &res, MX25519_UNCLAMP_254);
     assert(equals_hex(&res, inv_pubkey));
 #undef NUM_KEYS
     return true;
@@ -233,7 +253,7 @@ static bool test_scmul4_arm64() {
     if (impl == NULL) {
         return false;
     }
-    assert(check_scmul(test_sc4, test_pt4, test_re4));
+    assert(check_scmul_unclamped(test_sc4, test_pt4, test_re4, MX25519_UNCLAMP_254));
     return true;
 }
 
@@ -242,6 +262,21 @@ static bool test_dh_arm64() {
         return false;
     }
     check_dh();
+    return true;
+}
+
+static bool test_mul_base_times1_arm64() {
+    if (impl == NULL) {
+        return false;
+    }
+
+    // check that mx25519_scmul_base(1) == B
+    const mx25519_privkey one = {.data = {1}};
+    const mx25519_pubkey B = {.data = {9}};
+    mx25519_pubkey B1;
+    mx25519_scmul_base_unclamped(impl, &B1, &one, MX25519_UNCLAMP_ALL);
+
+    assert(memcmp(&B1, &B, sizeof(B)) == 0);
     return true;
 }
 
@@ -287,7 +322,7 @@ static bool test_scmul4_amd64() {
     if (impl == NULL) {
         return false;
     }
-    assert(check_scmul(test_sc4, test_pt4, test_re4));
+    assert(check_scmul_unclamped(test_sc4, test_pt4, test_re4, MX25519_UNCLAMP_254));
     return true;
 }
 
@@ -296,6 +331,21 @@ static bool test_dh_amd64() {
         return false;
     }
     check_dh();
+    return true;
+}
+
+static bool test_mul_base_times1_amd64() {
+    if (impl == NULL) {
+        return false;
+    }
+
+    // check that mx25519_scmul_base(1) == B
+    const mx25519_privkey one = {.data = {1}};
+    const mx25519_pubkey B = {.data = {9}};
+    mx25519_pubkey B1;
+    mx25519_scmul_base_unclamped(impl, &B1, &one, MX25519_UNCLAMP_ALL);
+
+    assert(memcmp(&B1, &B, sizeof(B)) == 0);
     return true;
 }
 
@@ -341,7 +391,7 @@ static bool test_scmul4_amd64x() {
     if (impl == NULL) {
         return false;
     }
-    assert(check_scmul(test_sc4, test_pt4, test_re4));
+    assert(check_scmul_unclamped(test_sc4, test_pt4, test_re4, MX25519_UNCLAMP_254));
     return true;
 }
 
@@ -350,6 +400,21 @@ static bool test_dh_amd64x() {
         return false;
     }
     check_dh();
+    return true;
+}
+
+static bool test_mul_base_times1_amd64x() {
+    if (impl == NULL) {
+        return false;
+    }
+
+    // check that mx25519_scmul_base(1) == B
+    const mx25519_privkey one = {.data = {1}};
+    const mx25519_pubkey B = {.data = {9}};
+    mx25519_pubkey B1;
+    mx25519_scmul_base_unclamped(impl, &B1, &one, MX25519_UNCLAMP_ALL);
+
+    assert(memcmp(&B1, &B, sizeof(B)) == 0);
     return true;
 }
 
@@ -362,6 +427,7 @@ int main() {
     RUN_TEST(test_scmul3_portable);
     RUN_TEST(test_scmul4_portable);
     RUN_TEST(test_dh_portable);
+    RUN_TEST(test_mul_base_times1_portable);
     RUN_TEST(test_invert1);
     RUN_TEST(test_invert2);
     RUN_TEST(test_select_arm64);
@@ -371,6 +437,7 @@ int main() {
     RUN_TEST(test_scmul3_arm64);
     RUN_TEST(test_scmul4_arm64);
     RUN_TEST(test_dh_arm64);
+    RUN_TEST(test_mul_base_times1_arm64);
     RUN_TEST(test_select_amd64);
     RUN_TEST(test_type_amd64);
     RUN_TEST(test_scmul1_amd64);
@@ -378,6 +445,7 @@ int main() {
     RUN_TEST(test_scmul3_amd64);
     RUN_TEST(test_scmul4_amd64);
     RUN_TEST(test_dh_amd64);
+    RUN_TEST(test_mul_base_times1_amd64);
     RUN_TEST(test_select_amd64x);
     RUN_TEST(test_type_amd64x);
     RUN_TEST(test_scmul1_amd64x);
@@ -385,6 +453,7 @@ int main() {
     RUN_TEST(test_scmul3_amd64x);
     RUN_TEST(test_scmul4_amd64x);
     RUN_TEST(test_dh_amd64x);
+    RUN_TEST(test_mul_base_times1_amd64x);
 
     printf("\nAll tests were successful\n");
     return 0;


### PR DESCRIPTION
This PR introduces a breaking change to the API, as well as new features. Now, `mx25519_scmul_base()` and `mx25519_scmul_key()` perform fully-clamped scalar-point multiplication, according to RFC 7748. We add 2 new functions: `mx25519_scmul_base_unclamped()` and `mx25519_scmul_key_unclamped()`. We also add a new enum: `mx25519_unclamp_flags`. For configurable unclamping of private keys, different values of `mx25519_unclamp_flags` can be passed to the `*_unclamped()` variants of the functions. `mx25519_unclamp_flags` may take on one of the following values: `MX25519_UNCLAMP_NONE`, `MX25519_UNCLAMP_LSBS`, `MX25519_UNCLAMP_254`, or `MX25519_UNCLAMP_ALL`. `MX25519_UNCLAMP_NONE` is RFC 7748. `MX25519_UNCLAMP_254` is the previous behavior of mx25519. `MX25519_UNCLAMP_ALL` is what is required by Carrot to support X25519 for existing Monero Ed25519 keys. `MX25519_UNCLAMP_LSBS` by itself is sort of strange, but it is supported.

This is part of upstreaming Carrot. 