### PR TITLE
Bump min required CMake version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 set(MX25519_VERSION 1)
 


### PR DESCRIPTION
CMake has deprecated support for 3.10 in newer versions: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html